### PR TITLE
Add option for delay between searches

### DIFF
--- a/src/jstable.js
+++ b/src/jstable.js
@@ -70,7 +70,9 @@ const JSTableDefaultConfig = {
     // append query params on events
     addQueryParams: true,
 
-    rowAttributesCreator: null
+    rowAttributesCreator: null,
+
+    searchDelay: null
 };
 
 class JSTable {
@@ -98,6 +100,7 @@ class JSTable {
         this.isSearching = false;
         this.dataCount = null;
         this.filteredDataCount = null;
+        this.searchTimeout = null;
 
 
         // init pager
@@ -408,6 +411,28 @@ class JSTable {
     }
 
     async search(query) {
+        // do nothing if the query has not changed since last search
+        if (this.searchQuery === query.toLowerCase()) {
+            return false;
+        }
+        
+        // do not perform another search before enough time has passed since the last
+        if (this.config.searchDelay) {
+            if (this.searchTimeout) {
+                return false;
+            } else {
+                // trigger search again after the given delay
+                this.searchTimeout = setTimeout(
+                    function () {
+                        that.searchTimeout = null;
+                        that._parseQueryParams();
+                    },
+                    this.config.searchDelay
+                );
+            }
+        }
+
+
         var that = this;
 
         this.searchQuery = query.toLowerCase();

--- a/src/jstable.js
+++ b/src/jstable.js
@@ -411,11 +411,15 @@ class JSTable {
     }
 
     async search(query) {
+        var that = this;
+
         // do nothing if the query has not changed since last search
         if (this.searchQuery === query.toLowerCase()) {
             return false;
         }
-        
+
+        this.searchQuery = query.toLowerCase();
+
         // do not perform another search before enough time has passed since the last
         if (this.config.searchDelay) {
             if (this.searchTimeout) {
@@ -431,11 +435,6 @@ class JSTable {
                 );
             }
         }
-
-
-        var that = this;
-
-        this.searchQuery = query.toLowerCase();
 
         // reset parameters
         this.currentPage = 1;


### PR DESCRIPTION
A new option named `searchDelay` has been added. The first search is triggered immediately to keep the first feedback as fast as possible. Afterwards, search is performed each time the timeout finishes.

Also added condition that checks if the search query has changed before performing the search. This prevents requests being triggered as a result of pressing keys that do not change the query (like arrow keys).

closes #27 