### PR TITLE
Fix search timeout replacing input value

### DIFF
--- a/src/jstable.js
+++ b/src/jstable.js
@@ -432,7 +432,6 @@ class JSTable {
                 this.searchTimeout = setTimeout(
                     function () {
                         that.searchTimeout = null;
-                        that._parseQueryParams();
                     },
                     this.config.searchDelay
                 );


### PR DESCRIPTION
I originally added support for search timeout in my previous pull request. Later, I discovered that when the timeout finishes, the value of the search input gets replaced with the value as it was when the timeout started. This change fixes the problem.