### PR TITLE
Extend url query params with perPage and sorting

### DIFF
--- a/src/jstable.js
+++ b/src/jstable.js
@@ -66,9 +66,9 @@ const JSTableDefaultConfig = {
     queryParams: {
         page: 'page',
         search: 'search',
-        sortColumn: 'sort_column',
-        sortDirection: 'sort_direction',
-        perPage: 'per_page'
+        sortColumn: 'sortColumn',
+        sortDirection: 'sortDirection',
+        perPage: 'perPage'
     },
     // append query params on events
     addQueryParams: true,
@@ -571,12 +571,10 @@ class JSTable {
     }
 
     _setQueryParam(key, value) {
-      var that = this;
-
-      if (!that.config.addQueryParams) return;
+      if (!this.config.addQueryParams) return;
 
       const url = new URL(window.location.href);
-      url.searchParams.set(that.config.queryParams[key], value);
+      url.searchParams.set(this.config.queryParams[key], value);
       window.history.replaceState(null, null, url);
     }
 


### PR DESCRIPTION
This PR extends the query parameters to store the selected number of rows per page and sorted column with direction.

There is a second PR in jstable.github.io repository to update the documentation.